### PR TITLE
Feat/refactor code structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,18 @@ directory. Images must be sortable by name (e.g., "1.jpg, 2.jpg..." or
 
 The CSV format:
 
-| no  | lens_maker  | lens_name               | focal_length | date                      | iso | aperture | shutter_speed | exposure_compensation |
-| --- | ----------- | ----------------------- | ------------ | ------------------------- | --- | -------- | ------------- | --------------------- |
-| 1   | VOIGTLANDER | NOKTON 35mm F1.5        | 35           | 2024:06:15 15:39:00+02:00 | 200 | 2.8      | 1/60          | 0.67                  |
-| 2   | LEICA       | APO SUMMICRON 50mm F2.0 | 50           | 2024:06:15 15:52:00+02:00 | 200 | 4.0      | 1/60          | 0                     |
+| no  | camera_maker | camera_name | lens_maker  | lens_name               | focal_length | date                      | iso | aperture | shutter_speed | exposure_compensation |
+| --- | ------------ | ----------- | ----------- | ----------------------- | ------------ | ------------------------- | --- | -------- | ------------- | --------------------- |
+| 1   | LEICA        | M6          | VOIGTLANDER | NOKTON 35mm F1.5        | 35           | 2024:06:15 15:39:00+02:00 | 200 | 2.8      | 1/60          | 0.67                  |
+| 2   | LEICA        | M6          | LEICA       | APO SUMMICRON 50mm F2.0 | 50           | 2024:06:15 15:52:00+02:00 | 200 | 4.0      | 1/60          | 0                     |
 
 An example file is in the `fixtures/` directory.
 
 ### Values in metadata.csv
 
 - **no:** Optional. For tracking shots.
+- **camera_maker:** String. Camera maker.
+- **camera_name:** String. Camera name.
 - **lens_maker:** String. Lens maker.
 - **lens_name:** String. Lens name.
 - **focal_length:** Integer. Lens focal length.

--- a/src/csv/mod.rs
+++ b/src/csv/mod.rs
@@ -1,0 +1,3 @@
+mod read;
+
+pub use read::*;

--- a/src/csv/read.rs
+++ b/src/csv/read.rs
@@ -5,7 +5,7 @@ use snafu::prelude::*;
 use std::path::Path;
 use std::str::FromStr;
 
-pub fn read_metadata(path: &Path) -> Result<Vec<ExposureInfo>, Error> {
+pub fn read(path: &Path) -> Result<Vec<ExposureInfo>, ReadError> {
     let mut rdr = csv::Reader::from_path(path).context(InvalidCSVSnafu)?;
 
     let mut res = Vec::new();
@@ -44,10 +44,10 @@ pub struct BuildExposureInfo {
 }
 
 impl ExposureInfo {
-    pub fn build(args: BuildExposureInfo) -> Result<ExposureInfo, Error> {
+    pub fn build(args: BuildExposureInfo) -> Result<ExposureInfo, ReadError> {
         if let Some(shutter_speed) = &args.shutter_speed {
             if !Self::is_shutter_speed_valid(shutter_speed) {
-                return Err(Error::InvalidShutterSpeed {
+                return Err(ReadError::InvalidShutterSpeed {
                     text: shutter_speed.to_string(),
                 });
             }
@@ -78,12 +78,12 @@ impl ExposureInfo {
 
 fn parse_exposure_compensation(
     exposure_compensation: &Option<String>,
-) -> Result<Option<f32>, Error> {
+) -> Result<Option<f32>, ReadError> {
     if let Some(exp_comp) = exposure_compensation {
         // This to allow the format of "1 1/3" or "2 2/3"
         let parts = exp_comp.split(" ").collect::<Vec<&str>>();
         if parts.len() > 2 {
-            return Err(Error::InvalidExposureCompensation {
+            return Err(ReadError::InvalidExposureCompensation {
                 value: exp_comp.clone(),
             });
         }
@@ -110,7 +110,7 @@ fn parse_exposure_compensation(
 }
 
 #[derive(Debug, Snafu)]
-pub enum Error {
+pub enum ReadError {
     #[snafu(display("The Shutter speed is incorrect: {} does not follow the pattern", text))]
     InvalidShutterSpeed { text: String },
 

--- a/src/csv/read.rs
+++ b/src/csv/read.rs
@@ -1,17 +1,14 @@
-use fraction::{error::ParseError, Fraction, ToPrimitive};
-use regex::Regex;
-use serde::Deserialize;
+use crate::exposure_info::{BuildExposureInfo, ExposureError, ExposureInfo};
 use snafu::prelude::*;
 use std::path::Path;
-use std::str::FromStr;
 
-pub fn read(path: &Path) -> Result<Vec<ExposureInfo>, ReadError> {
+pub fn read(path: &Path) -> Result<Vec<ExposureInfo>, Error> {
     let mut rdr = csv::Reader::from_path(path).context(InvalidCSVSnafu)?;
 
     let mut res = Vec::new();
     for exp in rdr.deserialize() {
         let args: BuildExposureInfo = exp.context(FailedToParseSnafu)?;
-        let exposure = ExposureInfo::build(args)?;
+        let exposure = ExposureInfo::build(args).context(ExposureSnafu)?;
 
         res.push(exposure);
     }
@@ -19,110 +16,16 @@ pub fn read(path: &Path) -> Result<Vec<ExposureInfo>, ReadError> {
     Ok(res)
 }
 
-#[derive(Debug)]
-pub struct ExposureInfo {
-    pub lens_name: Option<String>,
-    pub lens_maker: Option<String>,
-    pub focal_length: Option<f32>,
-    pub date: Option<String>,
-    pub iso: Option<i32>,
-    pub aperture: Option<f32>,
-    pub shutter_speed: Option<String>,
-    pub exposure_compensation: Option<f32>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct BuildExposureInfo {
-    lens_name: Option<String>,
-    lens_maker: Option<String>,
-    focal_length: Option<f32>,
-    date: Option<String>,
-    iso: Option<i32>,
-    aperture: Option<f32>,
-    shutter_speed: Option<String>,
-    exposure_compensation: Option<String>,
-}
-
-impl ExposureInfo {
-    pub fn build(args: BuildExposureInfo) -> Result<ExposureInfo, ReadError> {
-        if let Some(shutter_speed) = &args.shutter_speed {
-            if !Self::is_shutter_speed_valid(shutter_speed) {
-                return Err(ReadError::InvalidShutterSpeed {
-                    text: shutter_speed.to_string(),
-                });
-            }
-        }
-
-        let exp_comp = parse_exposure_compensation(&args.exposure_compensation)?;
-
-        let result = ExposureInfo {
-            lens_name: args.lens_name,
-            lens_maker: args.lens_maker,
-            date: args.date,
-            iso: args.iso,
-            focal_length: args.focal_length,
-            aperture: args.aperture,
-            shutter_speed: args.shutter_speed,
-            exposure_compensation: exp_comp,
-        };
-
-        Ok(result)
-    }
-
-    fn is_shutter_speed_valid(txt: &str) -> bool {
-        let expr = Regex::new(r#"1/\d+|\d+""#).unwrap();
-
-        expr.is_match(txt)
-    }
-}
-
-fn parse_exposure_compensation(
-    exposure_compensation: &Option<String>,
-) -> Result<Option<f32>, ReadError> {
-    if let Some(exp_comp) = exposure_compensation {
-        // This to allow the format of "1 1/3" or "2 2/3"
-        let parts = exp_comp.split(" ").collect::<Vec<&str>>();
-        if parts.len() > 2 {
-            return Err(ReadError::InvalidExposureCompensation {
-                value: exp_comp.clone(),
-            });
-        }
-
-        let float: f32 = parts.iter().fold(0.0, |acc, part| {
-            let float = Fraction::from_str(part)
-                .context(ExposureCompensationSnafu {
-                    value: exp_comp.clone(),
-                })
-                .unwrap();
-            let float: f32 = float.to_f32().unwrap();
-
-            if acc >= 0.0 {
-                acc + float
-            } else {
-                acc - float
-            }
-        });
-
-        Ok(Some(float))
-    } else {
-        Ok(None)
-    }
-}
+type Error = ReadError;
 
 #[derive(Debug, Snafu)]
 pub enum ReadError {
-    #[snafu(display("The Shutter speed is incorrect: {} does not follow the pattern", text))]
-    InvalidShutterSpeed { text: String },
-
-    #[snafu(display("Failed to read CSV: {:?}", source))]
+    #[snafu(display("Failed to read CSV: {}", source))]
     InvalidCSV { source: csv::Error },
 
-    #[snafu(display("Failed to deserialize the row: {:?}", source))]
+    #[snafu(display("Failed to deserialize the row: {}", source))]
     FailedToParse { source: csv::Error },
 
-    #[snafu(display("Wrong format for exposure compensation \"{}\": {:?}", value, source))]
-    ExposureCompensation { source: ParseError, value: String },
-
-    #[snafu(display("The format of the exposure compensation \"{}\" is wrong", value))]
-    InvalidExposureCompensation { value: String },
+    #[snafu(display("Failed to build the exposure value: {}", source))]
+    Exposure { source: ExposureError },
 }

--- a/src/exiftool/mod.rs
+++ b/src/exiftool/mod.rs
@@ -1,0 +1,4 @@
+mod spawn;
+mod update;
+
+pub use update::*;

--- a/src/exiftool/spawn.rs
+++ b/src/exiftool/spawn.rs
@@ -1,0 +1,22 @@
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
+#[cfg(target_os = "windows")]
+use winapi::um::winbase::CREATE_NO_WINDOW;
+
+#[cfg(not(target_os = "windows"))]
+pub fn spawn_exiftool(_exiftool_path: &Path) -> Command {
+    let cmd = Command::new("perl");
+
+    cmd
+}
+
+#[cfg(target_os = "windows")]
+pub fn spawn_exiftool(exiftool_path: &Path) -> Command {
+    let mut cmd = Command::new(exiftool_path);
+
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    cmd
+}

--- a/src/exiftool/spawn.rs
+++ b/src/exiftool/spawn.rs
@@ -7,9 +7,7 @@ use winapi::um::winbase::CREATE_NO_WINDOW;
 
 #[cfg(not(target_os = "windows"))]
 pub fn spawn_exiftool(_exiftool_path: &Path) -> Command {
-    let cmd = Command::new("perl");
-
-    cmd
+    Command::new("perl")
 }
 
 #[cfg(target_os = "windows")]

--- a/src/exiftool/update.rs
+++ b/src/exiftool/update.rs
@@ -1,5 +1,6 @@
-use super::paths::{project_root, Error as PathError};
-use crate::utils::read_metadata::ExposureInfo;
+use super::spawn::spawn_exiftool;
+use crate::csv::ExposureInfo;
+use crate::utils::paths::{project_root, Error as PathError};
 use console::Emoji;
 use indicatif::ProgressBar;
 use log::{debug, trace};
@@ -8,7 +9,7 @@ use std::io::Error as IOError;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 #[cfg(target_os = "windows")]
 use winapi::um::winbase::CREATE_NO_WINDOW;
 
@@ -20,9 +21,9 @@ pub fn update_exif_metadata(
     exposures: Vec<ExposureInfo>,
     model: Option<&str>,
     maker: Option<&str>,
-) -> Result<(), Error> {
+) -> Result<(), UpdateError> {
     if files.len() != exposures.len() {
-        return Err(Error::BadInformation {
+        return Err(UpdateError::BadInformation {
             photos: files.len(),
             exposures: exposures.len(),
         });
@@ -69,24 +70,8 @@ pub fn update_exif_metadata(
     Ok(())
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn spawn_exiftool(_exiftool_path: &Path) -> Result<Command, Error> {
-    let cmd = Command::new("perl");
-
-    Ok(cmd)
-}
-
-#[cfg(target_os = "windows")]
-pub fn spawn_exiftool(exiftool_path: &Path) -> Result<Command, Error> {
-    let mut cmd = Command::new(exiftool_path);
-
-    cmd.creation_flags(CREATE_NO_WINDOW);
-
-    Ok(cmd)
-}
-
-pub fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), Error> {
-    let mut cmd = spawn_exiftool(exiftool_path)?;
+fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), UpdateError> {
+    let mut cmd = spawn_exiftool(exiftool_path);
 
     #[cfg(not(target_os = "windows"))]
     let mut cmd = cmd.arg(exiftool_path);
@@ -165,7 +150,7 @@ pub fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), Error> {
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
 
-        Err(Error::ExiftoolExe {
+        Err(UpdateError::ExiftoolExe {
             stderr: stderr.to_string(),
         })
     }
@@ -179,7 +164,7 @@ pub struct ExifArgs<'a> {
 }
 
 #[derive(Debug, Snafu)]
-pub enum Error {
+pub enum UpdateError {
     #[snafu(display("The amount of images do not match the number of exposures, photos found: {}, exposures in metadata: {}", photos, exposures))]
     BadInformation { photos: usize, exposures: usize },
 

--- a/src/exiftool/update.rs
+++ b/src/exiftool/update.rs
@@ -1,6 +1,6 @@
 use super::spawn::spawn_exiftool;
-use crate::csv::ExposureInfo;
-use crate::utils::paths::{project_root, Error as PathError};
+use crate::exposure_info::ExposureInfo;
+use crate::utils::paths::{project_root, PathsError};
 use console::Emoji;
 use indicatif::ProgressBar;
 use log::{debug, trace};
@@ -21,9 +21,9 @@ pub fn update_exif_metadata(
     exposures: Vec<ExposureInfo>,
     model: Option<&str>,
     maker: Option<&str>,
-) -> Result<(), UpdateError> {
+) -> Result<(), Error> {
     if files.len() != exposures.len() {
-        return Err(UpdateError::BadInformation {
+        return Err(Error::BadInformation {
             photos: files.len(),
             exposures: exposures.len(),
         });
@@ -70,7 +70,7 @@ pub fn update_exif_metadata(
     Ok(())
 }
 
-fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), UpdateError> {
+fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), Error> {
     let mut cmd = spawn_exiftool(exiftool_path);
 
     #[cfg(not(target_os = "windows"))]
@@ -150,7 +150,7 @@ fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), UpdateError> {
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
 
-        Err(UpdateError::ExiftoolExe {
+        Err(Error::ExiftoolExe {
             stderr: stderr.to_string(),
         })
     }
@@ -162,6 +162,8 @@ pub struct ExifArgs<'a> {
     model: Option<&'a str>,
     maker: Option<&'a str>,
 }
+
+type Error = UpdateError;
 
 #[derive(Debug, Snafu)]
 pub enum UpdateError {
@@ -179,5 +181,5 @@ pub enum UpdateError {
     ExiftoolExe { stderr: String },
 
     #[snafu(display("Failed to get path for exiftool: {:?}", source))]
-    Path { source: PathError },
+    Path { source: PathsError },
 }

--- a/src/exiftool/update.rs
+++ b/src/exiftool/update.rs
@@ -13,15 +13,9 @@ use std::process::Output;
 #[cfg(target_os = "windows")]
 use winapi::um::winbase::CREATE_NO_WINDOW;
 
-static CAMERA: Emoji<'_, '_> = Emoji("📷 ", "");
 static FILM: Emoji<'_, '_> = Emoji("🎞️ ", "");
 
-pub fn update_exif_metadata(
-    files: Vec<String>,
-    exposures: Vec<ExposureInfo>,
-    model: Option<&str>,
-    maker: Option<&str>,
-) -> Result<(), Error> {
+pub fn update_exif_metadata(files: Vec<String>, exposures: Vec<ExposureInfo>) -> Result<(), Error> {
     if files.len() != exposures.len() {
         return Err(Error::BadInformation {
             photos: files.len(),
@@ -41,7 +35,6 @@ pub fn update_exif_metadata(
 
     println!("\n");
     println!("{}Processing {} Photos...", FILM, files.len());
-    println!("{}Camera: {:?} {:?}", CAMERA, maker, model);
     println!("\n");
 
     let pb = ProgressBar::new(files.len() as u64);
@@ -52,12 +45,7 @@ pub fn update_exif_metadata(
         trace!("File: {}", file);
         trace!("Exposure: {:?}", exposure);
 
-        let args = ExifArgs {
-            file,
-            model,
-            exposure,
-            maker,
-        };
+        let args = ExifArgs { file, exposure };
 
         exiftool(&args, &exiftool_path)?;
         trace!("\n");
@@ -114,11 +102,11 @@ fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), Error> {
         cmd = cmd.arg(format!("-LensMake={}", lens_maker));
     }
 
-    if let Some(maker) = args.maker {
+    if let Some(maker) = &args.exposure.camera_maker {
         cmd = cmd.arg(format!("-Make={}", maker));
     }
 
-    if let Some(model) = args.model {
+    if let Some(model) = &args.exposure.camera_name {
         cmd = cmd.arg(format!("-Model={}", model));
     }
 
@@ -159,8 +147,6 @@ fn exiftool(args: &ExifArgs, exiftool_path: &Path) -> Result<(), Error> {
 pub struct ExifArgs<'a> {
     file: &'a str,
     exposure: &'a ExposureInfo,
-    model: Option<&'a str>,
-    maker: Option<&'a str>,
 }
 
 type Error = UpdateError;

--- a/src/exiftool/update.rs
+++ b/src/exiftool/update.rs
@@ -6,12 +6,8 @@ use indicatif::ProgressBar;
 use log::{debug, trace};
 use snafu::prelude::*;
 use std::io::Error as IOError;
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
 use std::path::Path;
 use std::process::Output;
-#[cfg(target_os = "windows")]
-use winapi::um::winbase::CREATE_NO_WINDOW;
 
 static FILM: Emoji<'_, '_> = Emoji("🎞️ ", "");
 

--- a/src/exposure_info.rs
+++ b/src/exposure_info.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct ExposureInfo {
+    pub camera_name: Option<String>,
+    pub camera_maker: Option<String>,
     pub lens_name: Option<String>,
     pub lens_maker: Option<String>,
     pub focal_length: Option<f32>,
@@ -18,6 +20,8 @@ pub struct ExposureInfo {
 
 #[derive(Debug, Deserialize)]
 pub struct BuildExposureInfo {
+    camera_name: Option<String>,
+    camera_maker: Option<String>,
     lens_name: Option<String>,
     lens_maker: Option<String>,
     focal_length: Option<f32>,
@@ -41,6 +45,8 @@ impl ExposureInfo {
         let exp_comp = parse_exposure_compensation(&args.exposure_compensation)?;
 
         let result = ExposureInfo {
+            camera_name: args.camera_name,
+            camera_maker: args.camera_maker,
             lens_name: args.lens_name,
             lens_maker: args.lens_maker,
             date: args.date,

--- a/src/exposure_info.rs
+++ b/src/exposure_info.rs
@@ -1,0 +1,109 @@
+use fraction::{error::ParseError, Fraction, ToPrimitive};
+use regex::Regex;
+use serde::Deserialize;
+use snafu::prelude::*;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct ExposureInfo {
+    pub lens_name: Option<String>,
+    pub lens_maker: Option<String>,
+    pub focal_length: Option<f32>,
+    pub date: Option<String>,
+    pub iso: Option<i32>,
+    pub aperture: Option<f32>,
+    pub shutter_speed: Option<String>,
+    pub exposure_compensation: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BuildExposureInfo {
+    lens_name: Option<String>,
+    lens_maker: Option<String>,
+    focal_length: Option<f32>,
+    date: Option<String>,
+    iso: Option<i32>,
+    aperture: Option<f32>,
+    shutter_speed: Option<String>,
+    exposure_compensation: Option<String>,
+}
+
+impl ExposureInfo {
+    pub fn build(args: BuildExposureInfo) -> Result<ExposureInfo, Error> {
+        if let Some(shutter_speed) = &args.shutter_speed {
+            if !Self::is_shutter_speed_valid(shutter_speed) {
+                return Err(Error::InvalidShutterSpeed {
+                    text: shutter_speed.to_string(),
+                });
+            }
+        }
+
+        let exp_comp = parse_exposure_compensation(&args.exposure_compensation)?;
+
+        let result = ExposureInfo {
+            lens_name: args.lens_name,
+            lens_maker: args.lens_maker,
+            date: args.date,
+            iso: args.iso,
+            focal_length: args.focal_length,
+            aperture: args.aperture,
+            shutter_speed: args.shutter_speed,
+            exposure_compensation: exp_comp,
+        };
+
+        Ok(result)
+    }
+
+    fn is_shutter_speed_valid(txt: &str) -> bool {
+        let expr = Regex::new(r#"1/\d+|\d+""#).unwrap();
+
+        expr.is_match(txt)
+    }
+}
+
+fn parse_exposure_compensation(
+    exposure_compensation: &Option<String>,
+) -> Result<Option<f32>, Error> {
+    if let Some(exp_comp) = exposure_compensation {
+        // This to allow the format of "1 1/3" or "2 2/3"
+        let parts = exp_comp.split(" ").collect::<Vec<&str>>();
+        if parts.len() > 2 {
+            return Err(Error::InvalidExposureCompensation {
+                value: exp_comp.clone(),
+            });
+        }
+
+        let float: f32 = parts.iter().fold(0.0, |acc, part| {
+            let float = Fraction::from_str(part)
+                .context(ExposureCompensationSnafu {
+                    value: exp_comp.clone(),
+                })
+                .unwrap();
+            let float: f32 = float.to_f32().unwrap();
+
+            if acc >= 0.0 {
+                acc + float
+            } else {
+                acc - float
+            }
+        });
+
+        Ok(Some(float))
+    } else {
+        Ok(None)
+    }
+}
+
+type Error = ExposureError;
+
+#[derive(Debug, Snafu)]
+pub enum ExposureError {
+    #[snafu(display("The Shutter speed is incorrect: {} does not follow the pattern", text))]
+    InvalidShutterSpeed { text: String },
+
+    #[snafu(display("Wrong format for exposure compensation \"{}\": {:?}", value, source))]
+    ExposureCompensation { source: ParseError, value: String },
+
+    #[snafu(display("The format of the exposure compensation \"{}\" is wrong", value))]
+    InvalidExposureCompensation { value: String },
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod csv;
 mod exiftool;
+mod exposure_info;
 mod photos;
 mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,10 +34,7 @@ fn handle_exif_apply(args: ExifApplyArgs) {
     let photo_paths = get_paths(source_path).unwrap();
     let exposures = read(metadata_path).unwrap();
 
-    let model = args.camera.as_deref();
-    let maker = args.maker.as_deref();
-
-    let result = update_exif_metadata(photo_paths, exposures, model, maker);
+    let result = update_exif_metadata(photo_paths, exposures);
     match result {
         Ok(_) => debug!("Done"),
         Err(err) => {
@@ -72,14 +69,6 @@ struct ExifApplyArgs {
     /// Path for the csv file with the metadata.
     #[clap(short, long)]
     metadata: String,
-
-    /// Name of the camera
-    #[clap(short, long)]
-    camera: Option<String>,
-
-    /// Example: KONICA, NIKON, CANON
-    #[clap(short = 'k', long)]
-    maker: Option<String>,
 
     /// Name of the film
     #[clap(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
+mod csv;
+mod exiftool;
+mod photos;
 mod utils;
 
-use crate::utils::get_photos::get_photos;
-use crate::utils::read_metadata::read_metadata;
-use crate::utils::update_exif_metadata::update_exif_metadata;
+use crate::csv::read;
+use crate::exiftool::update_exif_metadata;
+use crate::photos::get_paths;
 use clap::{Parser, Subcommand};
 use dirs::home_dir;
 use dotenv::dotenv;
@@ -27,8 +30,8 @@ fn handle_exif_apply(args: ExifApplyArgs) {
     let source_path = Path::new(&args.source);
     let metadata_path = Path::new(&args.metadata);
 
-    let photo_paths = get_photos(source_path).unwrap();
-    let exposures = read_metadata(metadata_path).unwrap();
+    let photo_paths = get_paths(source_path).unwrap();
+    let exposures = read(metadata_path).unwrap();
 
     let model = args.camera.as_deref();
     let maker = args.maker.as_deref();

--- a/src/photos/mod.rs
+++ b/src/photos/mod.rs
@@ -1,0 +1,3 @@
+mod paths;
+
+pub use paths::*;

--- a/src/photos/paths.rs
+++ b/src/photos/paths.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 use walkdir::WalkDir;
 
-pub fn get_paths(dir: &Path) -> Result<Vec<String>, PathError> {
+pub fn get_paths(dir: &Path) -> Result<Vec<String>, Error> {
     if dir.is_file() {
         let info = get_path(&dir.to_path_buf())?;
         return Ok(vec![info]);
@@ -48,7 +48,7 @@ pub fn get_paths(dir: &Path) -> Result<Vec<String>, PathError> {
     Ok(photos)
 }
 
-fn get_path(path: &PathBuf) -> Result<String, PathError> {
+fn get_path(path: &PathBuf) -> Result<String, Error> {
     let metadata = fs::metadata(path).context(MetadataSnafu)?;
 
     let extension = path
@@ -60,14 +60,14 @@ fn get_path(path: &PathBuf) -> Result<String, PathError> {
     let file_type = metadata.file_type();
 
     if !file_type.is_file() || !is_photo(extension) {
-        return Err(PathError::InvalidExtension);
+        return Err(Error::InvalidExtension);
     }
 
     if let Some(p) = path.to_str() {
         return Ok(p.to_string());
     }
 
-    Err(PathError::InvalidFile)
+    Err(Error::InvalidFile)
 }
 
 fn is_photo(extension: &str) -> bool {
@@ -76,8 +76,10 @@ fn is_photo(extension: &str) -> bool {
         | "png")
 }
 
+type Error = PathsError;
+
 #[derive(Debug, Snafu)]
-pub enum PathError {
+pub enum PathsError {
     #[snafu(display("Failed to read metadata: {}", source))]
     Metadata { source: io::Error },
 

--- a/src/photos/paths.rs
+++ b/src/photos/paths.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 use walkdir::WalkDir;
 
-pub fn get_photos(dir: &Path) -> Result<Vec<String>, Error> {
+pub fn get_paths(dir: &Path) -> Result<Vec<String>, PathError> {
     if dir.is_file() {
-        let info = get_photo_info(&dir.to_path_buf())?;
+        let info = get_path(&dir.to_path_buf())?;
         return Ok(vec![info]);
     }
 
@@ -20,7 +20,7 @@ pub fn get_photos(dir: &Path) -> Result<Vec<String>, Error> {
                 return Ok(None);
             }
 
-            let info = match get_photo_info(&path.to_path_buf()) {
+            let info = match get_path(&path.to_path_buf()) {
                 Ok(i) => i,
                 Err(err) => {
                     warn!("Failed to get file information: {:?}", err);
@@ -48,7 +48,7 @@ pub fn get_photos(dir: &Path) -> Result<Vec<String>, Error> {
     Ok(photos)
 }
 
-fn get_photo_info(path: &PathBuf) -> Result<String, Error> {
+fn get_path(path: &PathBuf) -> Result<String, PathError> {
     let metadata = fs::metadata(path).context(MetadataSnafu)?;
 
     let extension = path
@@ -60,14 +60,14 @@ fn get_photo_info(path: &PathBuf) -> Result<String, Error> {
     let file_type = metadata.file_type();
 
     if !file_type.is_file() || !is_photo(extension) {
-        return Err(Error::InvalidExtension);
+        return Err(PathError::InvalidExtension);
     }
 
     if let Some(p) = path.to_str() {
         return Ok(p.to_string());
     }
 
-    Err(Error::InvalidFile)
+    Err(PathError::InvalidFile)
 }
 
 fn is_photo(extension: &str) -> bool {
@@ -77,7 +77,7 @@ fn is_photo(extension: &str) -> bool {
 }
 
 #[derive(Debug, Snafu)]
-pub enum Error {
+pub enum PathError {
     #[snafu(display("Failed to read metadata: {}", source))]
     Metadata { source: io::Error },
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,1 @@
-pub mod get_photos;
-mod paths;
-pub mod read_metadata;
-pub mod update_exif_metadata;
+pub mod paths;

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -27,8 +27,10 @@ pub fn project_root() -> Result<PathBuf, Error> {
     unimplemented!()
 }
 
+type Error = PathsError;
+
 #[derive(Debug, Snafu)]
-pub enum Error {
+pub enum PathsError {
     #[snafu(display("Failed to get current dir: {:?}", source))]
     CurrentDir { source: std::io::Error },
 


### PR DESCRIPTION
## Description

This PR splits the code in modules rather than having an unholy `utils` path. Additionally, the camera model and maker are now part of the exposure info, specifically to deal with interchangeable backs from medium format cameras.